### PR TITLE
Corrected misspelled word and corrected the way to display alert box

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -12,7 +12,7 @@
                 <div class="col-xs-12">
                     <p>
                         <a href="https://github.com/omise/omise-php" target="_blank"><strong>OMISE-PHP</strong></a> is a library for connect with Omise Payment Gateway services (see more <a href="https://docs.omise.co/" target="_blank">https://docs.omise.co/</a>).
-                        <br/>So, All of files in this directory will show you about the best pratice that you should do when try to implement **omise-php** into your project.
+                        <br/>So, all of files in this directory will show you about the best pratices that you should do when implementing **omise-php** into your project.
                     </p>
                 </div> <!-- /END .col-xs-12 -->
             </div> <!-- /END .row -->

--- a/php/services/account.php
+++ b/php/services/account.php
@@ -16,7 +16,9 @@ try {
     print_r($account);
     echo "</pre>";
 } catch (Exception $e) {
-    echo 'Error <strong>'.$e->getMessage().'</strong><br/>Please try again.';
+    echo '<a href="../" style="display:block; margin-top: 20px;">back</a>';
+    echo "<h3>Account Object Status.</h3>";
+    echo '<div class="alert alert-danger">Error <strong>'.$e->getMessage().'</strong><br/>Please try again.</div>';
 }
 ?>
 

--- a/php/services/balance.php
+++ b/php/services/balance.php
@@ -16,7 +16,9 @@ try {
     print_r($balance);
     echo "</pre>";
 } catch (Exception $e) {
-    echo 'Error <strong>'.$e->getMessage().'</strong><br/>Please try again.';
+    echo '<a href="../" style="display:block; margin-top: 20px;">back</a>';
+    echo "<h3>Balance Object Status.</h3>";
+    echo '<div class="alert alert-danger">Error <strong>'.$e->getMessage().'</strong><br/>Please try again.</div>';
 }
 ?>
 

--- a/php/services/checkout.php
+++ b/php/services/checkout.php
@@ -25,9 +25,11 @@ if (isset($_POST['omise_token'])) {
         echo "</pre>";
     } catch (OmiseException $e) {
         echo '<a href="../" style="display:block; margin-top: 20px;">back</a>';
+        echo '<h3>Charged status.</h3>';
         echo '<div class="alert alert-danger">Error <strong>'.$e->getMessage().'</strong><br/>Please try again.</div>';
     }   
 } else {
+    echo '<a href="../" style="display:block; margin-top: 20px;">back</a>';
     echo '<div class="alert alert-warning">Not support GET request.</div>';
 }
 ?>

--- a/php/views/header.php
+++ b/php/views/header.php
@@ -12,7 +12,7 @@
                 <div class="col-xs-12">
                     <p>
                         <a href="https://github.com/omise/omise-php" target="_blank"><strong>OMISE-PHP</strong></a> is a library for connect with Omise Payment Gateway services (see more <a href="https://docs.omise.co/" target="_blank">https://docs.omise.co/</a>).
-                        <br/>So, All of files in this directory will show you about the best pratice that you should do when try to implement **omise-php** into your project.
+                        <br/>So, all of files in this directory will show you about the best pratices that you should do when implementing **omise-php** into your project.
                     </p>
                 </div> <!-- /END .col-xs-12 -->
             </div> <!-- /END .row -->


### PR DESCRIPTION
## Hotfix PR Purpose
- Corrected misspelled word in page header
- Corrected the way to display alert box if error occur (in services/\* folder)

...  
### Corrected misspelled word in page header

from @fred updated README.md in previous merged,
It need to correct a misspelled in page header too
### Corrected the way to display alert box if error occur (in services/\* folder)

I missed some class for display alert box in the right way when service's error occur

Thanks
